### PR TITLE
Add user documentation

### DIFF
--- a/data/regimes/readme.md
+++ b/data/regimes/readme.md
@@ -1,0 +1,25 @@
+![alt tag](https://raw.githubusercontent.com/QuantConnect/Lean/master/Documentation/logo.white.small.png) 
+## Market Regimes Data
+
+### Introduction
+
+Being able to reliably backtest against known and identifiable market regimes, allows both us and our users to compare the different trading algorithms in this repository. The trading data in this directory represents the 6 different market regimes:
+
+- Uptrend, with high volitility
+- Uptrend, with low volitility
+- Lateral, with high volitility
+- Lateral, with low volitility
+- Downtrend, with high volitility
+- Downtrend, with low volitility
+
+This data was all sourced from historial Apple, Inc. (AAPL) trading data, over varying time frames*.
+
+\*This is because attempting to find all six regimes in real world data will most likely not all adhere to the same time frames. We did attempt to generate this data to allow for more continuity between the different data sets, but this proved more time consuming then manually finding them in the wild so to speak.
+
+### Folder Structure
+
+Within this directory, we have included the raw historical trading data in CSV format, as well as accompanying visual representations of the data to note the volitility and trend direction. The different data sets and visual representations are labelled both using the regime data found above:
+
+- Uptrend, with high volitility: `data/regimes/uptrend-high-volitility.[csv|png]`
+- Lateral, with high volitility: `data/regimes/lateral-high-volitility.[csv|png]`
+- Downtrend, with high volitility: `data/regimes/downtrend-high-volitility.[csv|png]`

--- a/lean.json
+++ b/lean.json
@@ -1,5 +1,5 @@
 {
-  "file-database-last-update": "04/27/2022",
+  "file-database-last-update": "05/01/2022",
   // this configuration file works by first loading all top-level
   // configuration items and then will load the specified environment
   // on top, this provides a layering affect. environment names can be

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,45 @@
+![alt tag](https://raw.githubusercontent.com/QuantConnect/Lean/master/Documentation/logo.white.small.png) 
+# Algorithmic Stock Market Trading Strategies
+
+## Introduction
+
+This repo contains several stock trading algorithms which have been created and iterated on using the [Lean trading engine CLI](https://www.lean.io/cli/). These algorithms each attempt to use one or more of the "principles of price behavior":
+
+- __Principle #1__: *A Trend Has a Higher Probability of Continuation than Reversal*
+- __Principle #2__: *Momentum Preceeds Price*
+- __Principle #3__: *Trends End in a Climax*
+- __Principle #4__: *The Market Alternates between Range Expansion and Range Contraction*
+
+Using these principles as a basis for functionality, you can see how the logic in each algorithm is constructed around detecting and executing trades based on the indicators being detected.
+
+## Getting Started
+
+In order to backtest and analyze these algorithms, you will need to make sure that you have followed the directions for [installing the Lean CLI](https://www.lean.io/docs/lean-cli/key-concepts/getting-started).
+
+Once you have confirmed you have the required prerequisites and have the Lean CLI installed and running, you should be able to backtest the `example` algorithm to verify (run from project root directory):
+
+```
+lean backtest example
+```
+
+## Project Structure
+
+This project is constructed with a `data/` directory (which houses all the testing data used in our backtesting and iteration) as well as multiple `<algorithm>/` directories (see [`example`](example/)), which each follow the same basic [Lean Python project structure](https://www.lean.io/docs/lean-cli/projects/structure#02-Python-Project-Structure).
+
+### Data
+
+All the data used in backtesting and verification is stored within the `data/` directory in this project (if you need to define a new location for your personal testing data, you can make that change in the [`lean.json`](lean.json)). Most of our current testing data can be found in `data/yahoo/`, as this is where we have pulled the majority of our data.
+
+Specific market regime data can be found under the `data/regimes/` directory, but changes will need to be made in the algorithm if you wish to backtest it against this data. We are hoping to improve this in the future.
+
+### Algorithms
+
+Within each algorithm directory, we have also included some extra functionality to make backtesting and gathering trading data easier. These extra methods rely on including the [Yahoo_Fin](http://theautomatic.net/yahoo_fin-documentation/) Python library (hence the `requirements.txt`). We included this as a custom Python library which can be excluded if needed using the [directions provided by Lean](https://www.lean.io/docs/lean-cli/projects/libraries/third-party-libraries#05-Custom-Python-Libraries):
+
+- `yahoo_loader.py` - defines functionality for pulling down trading data from Yahoo Finance, and storing it in a file based on the ticket key, i.e. it will pull data for *TQQQ* from Yahoo Finance for a given date range and store it in a file `data/yahoo/TQQQ.csv`
+- `yahoo_reader.py` - defines the custom data type `YahooData` we serialize the raw trading data into, which Lean can then analyze and run against
+- `requirements.txt` - includes the manifest of all custom Python libraries included/used in the encompassing algorithm
+
+## Caveats
+
+This is still a very much work in progress project, so there will most likely be changes and updates made which might affect any of the above information before it can also be updated. Hopefully, we can improve on the user experience and have more immediate comparisons and quick start guides for the different algorithms in question.


### PR DESCRIPTION
This should add a README for both the newly added regime data and how t's broken down, as well as one for the overarching project, our algorithms, and how to get up and running backtesting them. These will most likely need a lot of updates as we progress and add functionality/change how we test them, but I wanted to make sure we had something to start with for the midpoint assignment.

I will update this PR and point it towards the `main` branch once my other PR is merged: https://github.com/scheffeltravis/Stock-Trading-Algorithms/pull/6